### PR TITLE
HPCC-27484 Set Terraform Azure resource management version to <=2.99.0 until support is added for v3.00.0

### DIFF
--- a/modules/storage_account/providers.tf
+++ b/modules/storage_account/providers.tf
@@ -1,17 +1,3 @@
-terraform {
-  required_providers {
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.1.0"
-    }
-
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 2.74.0"
-    }
-  }
-}
-
 provider "random" {
 }
 

--- a/modules/storage_account/versions.tf
+++ b/modules/storage_account/versions.tf
@@ -8,14 +8,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">=3.1.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">=2.2.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">=2.1.2"
-    }
   }
   required_version = ">=0.15.0"
 }

--- a/modules/virtual_network/providers.tf
+++ b/modules/virtual_network/providers.tf
@@ -1,3 +1,5 @@
+provider "random" {
+}
 provider "azurerm" {
   features {}
 }

--- a/modules/virtual_network/versions.tf
+++ b/modules/virtual_network/versions.tf
@@ -8,14 +8,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">=3.1.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">=2.2.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">=2.1.2"
-    }
   }
   required_version = ">=0.15.0"
 }


### PR DESCRIPTION
The Terraform Azure resource management provider v3.0 has dropped support for certain things that used to work in v2.99.0. We should retain the provider to versions <=2.99.0 until support is provided for v3.00.0.

```
virtual_network git:(main) terraform apply -var-file=admin.tfvars -auto-approve
╷
│ Error: expected filter_by_category.0 to be one of [HighAvailability Security Performance Cost OperationalExcellence], got cost
│ 
│   with data.azurerm_advisor_recommendations.advisor,
│   on data.tf line 3, in data "azurerm_advisor_recommendations" "advisor":
│    3:   filter_by_category        = ["security", "cost"]
│ 
╵
╷
│ Error: expected filter_by_category.1 to be one of [HighAvailability Security Performance Cost OperationalExcellence], got security
│ 
│   with data.azurerm_advisor_recommendations.advisor,
│   on data.tf line 3, in data "azurerm_advisor_recommendations" "advisor":
│    3:   filter_by_category        = ["security", "cost"]
```

Signed-off-by: Godson Fortil <godson.fortil@lexisnexisrisk.com>