### PR TITLE
HPCC-27460 Fix invalid index error

### DIFF
--- a/examples/admin.tfvars
+++ b/examples/admin.tfvars
@@ -119,9 +119,9 @@ auto_launch_eclwatch = true
 /*
   # Provide an existing virtual network deployed outside of this project
   virtual_network = {
-    private_subnet_id = ""
-    public_subnet_id  = ""
-    route_table_id    = ""
-    location          = ""
+    private_subnet_id = "value"
+    public_subnet_id  = "value"
+    route_table_id    = "value"
+    location          = "value"
   }
 */

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,7 @@ locals {
     var.metadata.resource_group_type != "" ? { resource_group_type = var.metadata.resource_group_type } : {}
   ) : module.metadata.names
   tags            = var.disable_naming_conventions ? merge(var.tags, { "admin" = var.admin.name, "email" = var.admin.email }) : merge(module.metadata.tags, { "admin" = var.admin.name, "email" = var.admin.email }, try(var.tags))
-  virtual_network = var.virtual_network != null ? var.virtual_network : data.external.vnet[0].result
+  virtual_network = can(var.virtual_network.private_subnet_id) && can(var.virtual_network.public_subnet_id) && can(var.virtual_network.route_table_id) ? var.virtual_network : data.external.vnet[0].result
   cluster_name    = "${local.names.resource_group_type}-${local.names.product_name}-terraform-${local.names.location}-${var.admin.name}-${terraform.workspace}"
 
   hpcc_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/hpcc-${var.hpcc.version}.tgz"
@@ -23,7 +23,7 @@ locals {
   storage_version    = can(var.storage.version) ? var.storage.version : "0.1.0"
   storage_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/hpcc-azurefile-${local.storage_version}.tgz"
   storage_chart      = can(var.storage.chart) ? var.storage.chart : local.storage_repository
-  storage_account    = try(try(var.storage.storage_account, data.external.sa[0].result), "")
+  storage_account    = can(var.storage.storage_account.resource_group_name) && can(var.storage.storage_account.name) && can(var.storage.storage_account.location) ? var.storage.storage_account : data.external.sa[0].result
 
   elk_version    = can(var.elk.version) ? var.elk.version : "1.2.1"
   elk_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/elastic4hpcclogs-${local.elk_version}.tgz"

--- a/modules/storage_account/data.tf
+++ b/modules/storage_account/data.tf
@@ -6,7 +6,7 @@ data "azurerm_subscription" "current" {
 }
 
 data "external" "vnet" {
-  count   = can(var.virtual_network.private_subnet_id) ? 0 : 1
+  count   = can(var.virtual_network.private_subnet_id) && can(var.virtual_network.public_subnet_id) ? 0 : 1
   program = ["python", "../virtual_network/bin/run.py"]
 
   query = {

--- a/modules/storage_account/examples/admin.tfvars
+++ b/modules/storage_account/examples/admin.tfvars
@@ -42,10 +42,10 @@ storage = {
 
 # Provide an existing virtual network deployed outside of this project
 /*
-  virtual_network = {
-    private_subnet_id = ""
-    public_subnet_id  = ""
-    route_table_id    = ""
-    location          = ""
-  }
+virtual_network = {
+  location       = "value"
+  route_table_id = "value"
+  private_subnet_id = "value"
+  public_subnet_id  = "value"
+}
 */

--- a/modules/storage_account/locals.tf
+++ b/modules/storage_account/locals.tf
@@ -12,10 +12,9 @@ locals {
     var.metadata.resource_group_type != "" ? { resource_group_type = var.metadata.resource_group_type } : {}
   ) : module.metadata.names
 
-  tags            = var.disable_naming_conventions ? merge(var.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }) : merge(module.metadata.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }, try(var.tags))
-  tovnet          = tomap({ "private_subnet_id" = data.external.vnet[0].result.private_subnet_id, "public_subnet_id" = data.external.vnet[0].result.public_subnet_id, "location" = data.external.vnet[0].result.location })
-  virtual_network = try(local.tovnet, var.virtual_network)
-  resource_group  = { location = try(var.resource_group.location, data.external.vnet[0].result.location) }
+  tags     = var.disable_naming_conventions ? merge(var.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }) : merge(module.metadata.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }, try(var.tags))
+  vnet     = can(var.virtual_network.private_subnet_id) && can(var.virtual_network.public_subnet_id) ? tomap({ private_subnet_id = var.virtual_network.private_subnet_id, public_subnet_id = var.virtual_network.public_subnet_id }) : tomap({ private_subnet_id = data.external.vnet[0].result.private_subnet_id, public_subnet_id = data.external.vnet[0].result.public_subnet_id })
+  location = can(var.virtual_network.location) ? var.virtual_network.location : data.external.vnet[0].result.location
   storage_shares = { "dalishare" = var.storage.quotas.dali, "dllsshare" = var.storage.quotas.dll, "sashashare" = var.storage.quotas.sasha,
   "datashare" = var.storage.quotas.data, "lzshare" = var.storage.quotas.lz }
 }

--- a/modules/storage_account/main.tf
+++ b/modules/storage_account/main.tf
@@ -21,7 +21,7 @@ module "metadata" {
   naming_rules = module.naming.yaml
 
   market              = var.metadata.market
-  location            = local.virtual_network.location
+  location            = local.location
   sre_team            = var.metadata.sre_team
   environment         = var.metadata.environment
   product_name        = var.metadata.product_name
@@ -37,7 +37,7 @@ module "resource_group" {
   source = "github.com/Azure-Terraform/terraform-azurerm-resource-group.git?ref=v2.0.0"
 
   unique_name = var.resource_group.unique_name
-  location    = local.virtual_network.location
+  location    = local.location
   names       = local.names
   tags        = local.tags
 }
@@ -60,7 +60,7 @@ module "storage_account" {
     "my_ip" = data.http.host_ip.body
   }
 
-  service_endpoints = local.virtual_network
+  service_endpoints = local.vnet
 }
 
 resource "azurerm_storage_share" "storage_shares" {

--- a/modules/storage_account/providers.tf
+++ b/modules/storage_account/providers.tf
@@ -1,7 +1,5 @@
 provider "random" {
 }
-
 provider "azurerm" {
   features {}
 }
-

--- a/modules/storage_account/variables.tf
+++ b/modules/storage_account/variables.tf
@@ -30,7 +30,7 @@ variable "resource_group" {
 variable "storage" {
   description = "HPCC Helm chart variables."
   type        = any
-  default     = { default = {} }
+  default     = {}
 }
 
 variable "tags" {
@@ -41,5 +41,5 @@ variable "tags" {
 variable "virtual_network" {
   description = "Subnet IDs"
   type        = any
-  default     = { default = {} }
+  default     = {}
 }

--- a/modules/virtual_network/locals.tf
+++ b/modules/virtual_network/locals.tf
@@ -18,4 +18,11 @@ locals {
   private_subnet_id = module.virtual_network.aks.hpcc.subnets["private"].id
   public_subnet_id  = module.virtual_network.aks.hpcc.subnets["public"].id
   route_table_id    = module.virtual_network.aks.hpcc.route_table_id
+
+  vnet = jsonencode({
+    "private_subnet_id" : "${local.private_subnet_id}",
+    "public_subnet_id" : "${local.public_subnet_id}",
+    "location" : "${module.resource_group.location}",
+    "route_table_id" : "${local.route_table_id}"
+  })
 }

--- a/modules/virtual_network/outputs.tf
+++ b/modules/virtual_network/outputs.tf
@@ -15,7 +15,7 @@ output "route_table_id" {
 }
 
 resource "local_file" "output" {
-  content  = "{ \"location\":\"${module.resource_group.location}\", \"private_subnet_id\" : \"${local.private_subnet_id}\", \"public_subnet_id\" : \"${local.public_subnet_id}\", \"route_table_id\" : \"${local.route_table_id}\" }"
+  content  = local.vnet
   filename = "${path.module}/bin/outputs.json"
 }
 


### PR DESCRIPTION
This error occurs when users try to import their own virtual network. The intended behavior was to not fetch data from the incorporated virtual network module once the virtual_network block is set. However, the current behavior is that Terraform tries to fetch even when it wouldn't use that data from the incorporated module. The issue is due to the use of try and catch. The correct implementation should use the can() function instead. To successfully test this, the host machine must not have python installed and the tester needs to import their own virtual network.

Signed-off-by: Godson Fortil <godson.fortil@lexisnexisrisk.com>