### PR TITLE
HPCC-27129 Add support for private Docker repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,22 +243,6 @@ Usage Example:
     }
 <br>
 
-### The `image_root` argument:
-This block contains information about the HPCC image to use. This block is optional.
-
- | Name       | Description        | Type   | Default     | Required |
- | ---------- | ------------------ | ------ | ----------- | :------: |
- | image_root | Image root to use. | string | hpccsystems |    no    |
-<br>
-
-### The `image_name` argument:
-This block contains information about the HPCC image to use. This block is optional.
-
- | Name       | Description        | Type   | Default       | Required |
- | ---------- | ------------------ | ------ | ------------- | :------: |
- | image_name | Image name to use. | string | platform-core |    mo    |
-<br>
-
 ### The `disable_helm` argument:
 This block disable helm deployments by Terraform. This block is optional and will stop HPCC from being installed.
 
@@ -270,13 +254,16 @@ This block disable helm deployments by Terraform. This block is optional and wil
 ### The `hpcc` block:
 This block deploys the HPCC helm chart. This block is optional.
 
- | Name      | Description                                                             | Type         | Default                          | Required |
- | --------- | ----------------------------------------------------------------------- | ------------ | -------------------------------- | :------: |
- | chart     | Path to local chart directory name. Examples: ~/HPCC-Platform/helm/hpcc | string       | null                             |    no    |
- | namespace | Namespace to use.                                                       | string       | default                          |    no    |
- | name      | Release name of the chart.                                              | string       | `myhpcck8s`                      |    no    |
- | values    | List of desired state files to use similar to -f in CLI.                | list(string) | `values-retained-azurefile.yaml` |    no    |
- | version   | Version of the HPCC chart.                                              | string       | latest                           |   yes    |
+ | Name          | Description                                                             | Type         | Default                          | Required |
+ | ------------- | ----------------------------------------------------------------------- | ------------ | -------------------------------- | :------: |
+ | chart         | Path to local chart directory name. Examples: ~/HPCC-Platform/helm/hpcc | string       | null                             |    no    |
+ | namespace     | Namespace to use.                                                       | string       | default                          |    no    |
+ | name          | Release name of the chart.                                              | string       | `myhpcck8s`                      |    no    |
+ | values        | List of desired state files to use similar to -f in CLI.                | list(string) | `values-retained-azurefile.yaml` |    no    |
+ | chart_version | Version of the HPCC chart.                                              | string       | latest                           |   yes    |
+ | image_root    | HPCC image root to use.                                                 | string       | hpccsystems                      |    no    |
+ | image_name    | HPCC image name to use.                                                 | string       | platform-core                    |    no    |
+ | image_version | HPCC image version to use.                                              | string       | 8.6.20-rc1                       |    no    |
 <br>
 
  Usage Example:
@@ -371,6 +358,25 @@ The `hpcc`, `storage` and `elk` blocks also support the following arguments:
 | lint                       | Optional           | Run the helm chart linter during the plan. Defaults to false.                                                                                                      |
 <br>
 
+### The `registry` block:
+This block authenticates a private Docker repository. This block is optional.
+
+ | Name     | Description                                                                | Type   | Default | Required |
+ | -------- | -------------------------------------------------------------------------- | ------ | ------- | :------: |
+ | server   | The server address of the private Docker repository.                       | string | -       |   yes    |
+ | username | The username for the private Docker repository account.                    | string | -       |   yes    |
+ | password | The password, token, or API key for the private Docker repository account. | string | -       |   yes    |
+<br>
+
+Usage Example:
+<br>
+
+    registry = {
+        password = ""
+        server   = ""
+        username = ""
+    }
+<br>
 
 ### The `auto_connect` argument:
 This block automatically connect your cluster to your local machine similarly to `az aks get-credentials`.
@@ -378,14 +384,6 @@ This block automatically connect your cluster to your local machine similarly to
  | Name         | Description                                                                                               | Type | Default | Required |
  | ------------ | --------------------------------------------------------------------------------------------------------- | ---- | ------- | :------: |
  | auto_connect | Automatically connect to the Kubernetes cluster from the host machine by overwriting the current context. | bool | `false` |    no    |
-<br>
-
-### The `auto_connect` argument:
-This block automatically launch the ECLWatch interface.
-
- | Name                 | Description                                  | Type | Default | Required |
- | -------------------- | -------------------------------------------- | ---- | ------- | :------: |
- | auto_launch_eclwatch | Automatically launch the ECLWatch interface. | bool | `false` |    no    |
 <br>
 
 ### The `expose_services` argument:

--- a/examples/admin.tfvars
+++ b/examples/admin.tfvars
@@ -62,16 +62,19 @@ node_pools = {
 # .......................
 
 hpcc = {
-  version = "8.4.14-rc1"
+  version = "8.6.20-rc1"
   name    = "myhpcck8s"
   atomic  = true
+  # image_root    = "<server-address>/<repository name>"
+  # image_name    = "platform-core-ln"
+  # image_version = "8.6.18-rc1"
 }
 
 elk = {
   enable = false
   name   = "myhpccelk"
   # chart  = ""
-  # values = ""
+  # values = []
 }
 
 storage = {
@@ -95,15 +98,6 @@ storage = {
 # Setting this to true can cause eclwatch service to stick in a pending state. Only use this if you know what you are doing.
 expose_services = true
 
-# image_root - Root of the image other than hpccsystems
-#  image_root = "foo"
-
-# image_name - Name of the image other than platform-core
-# image_name = "bar"
-
-# image_version - Version of the image
-# image_version = "bar"
-
 # auto_connect - Automatically connect to the kubernetes cluster from the host machine.
 auto_connect = true
 
@@ -124,4 +118,13 @@ auto_launch_eclwatch = true
     route_table_id    = "value"
     location          = "value"
   }
+*/
+
+/*
+# Private Docker repository authentification
+registry = {
+  password = "my_api_key"
+  server   = "westus.lexisnexisrisk.com"
+  username = "foo@lexisnexisrisk.com"
+}
 */

--- a/locals.tf
+++ b/locals.tf
@@ -15,17 +15,17 @@ locals {
   virtual_network = can(var.virtual_network.private_subnet_id) && can(var.virtual_network.public_subnet_id) && can(var.virtual_network.route_table_id) ? var.virtual_network : data.external.vnet[0].result
   cluster_name    = "${local.names.resource_group_type}-${local.names.product_name}-terraform-${local.names.location}-${var.admin.name}-${terraform.workspace}"
 
-  hpcc_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/hpcc-${var.hpcc.version}.tgz"
+  hpcc_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/hpcc-${var.hpcc.chart_version}.tgz"
   hpcc_chart      = can(var.hpcc.chart) ? var.hpcc.chart : local.hpcc_repository
   hpcc_name       = can(var.hpcc.name) ? var.hpcc.name : "myhpcck8s"
 
 
-  storage_version    = can(var.storage.version) ? var.storage.version : "0.1.0"
+  storage_version    = can(var.storage.chart_version) ? var.storage.chart_version : "0.1.0"
   storage_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/hpcc-azurefile-${local.storage_version}.tgz"
   storage_chart      = can(var.storage.chart) ? var.storage.chart : local.storage_repository
   storage_account    = can(var.storage.storage_account.resource_group_name) && can(var.storage.storage_account.name) && can(var.storage.storage_account.location) ? var.storage.storage_account : data.external.sa[0].result
 
-  elk_version    = can(var.elk.version) ? var.elk.version : "1.2.1"
+  elk_version    = can(var.elk.chart_version) ? var.elk.chart_version : "1.2.1"
   elk_repository = "https://github.com/hpcc-systems/helm-chart/raw/master/docs/elastic4hpcclogs-${local.elk_version}.tgz"
   elk_chart      = can(var.elk.chart) ? var.elk.chart : local.elk_repository
   elk_name       = can(var.elk.name) ? var.elk.name : "myhpccelk"

--- a/variables.tf
+++ b/variables.tf
@@ -134,3 +134,9 @@ variable "elk" {
   type        = any
   default     = { default = { name = "myhpccelk", enable = true } }
 }
+
+variable "registry" {
+  description = "Use if image is hosted on a private docker repository."
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
This feature will allow users to make use of private Docker repos, such as JFrog and Dockerhub.

Signed-off-by: Godson Fortil <godson.fortil@lexisnexisrisk.com>