### PR TITLE
HPCC-27436 Change the order the charts are deployed to improve optimization.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,11 @@ resource "helm_release" "hpcc" {
     }
   }
 
-  depends_on = [helm_release.storage, module.kubernetes]
+  depends_on = [
+    helm_release.elk,
+    helm_release.storage,
+    module.kubernetes
+  ]
 }
 
 resource "helm_release" "elk" {
@@ -189,6 +193,10 @@ resource "helm_release" "elk" {
   timeout                    = try(var.elk.timeout, 600)
   wait_for_jobs              = try(var.elk.wait_for_jobs, null)
   lint                       = try(var.elk.lint, null)
+
+  depends_on = [
+    helm_release.storage
+  ]
 }
 
 resource "helm_release" "storage" {


### PR DESCRIPTION
elk4hpcclogs was taking a long time to deploy because it relies on the storage to be deployed first.
Signed-off-by: Godson Fortil <godson.fortil@lexisnexisrisk.com>