### PR TITLE
Terraform should automatically configure ELK as logaccess target

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -35,3 +35,8 @@ data "external" "sa" {
     data_file = "modules/storage_account/bin/outputs.json"
   }
 }
+
+data "http" "elastic4hpcclogs_hpcc_logaccess" {
+  
+  url = local.elastic4hpcclogs_hpcc_logaccess
+}

--- a/locals.tf
+++ b/locals.tf
@@ -16,7 +16,8 @@ locals {
   cluster_name    = "${local.names.resource_group_type}-${local.names.product_name}-terraform-${local.names.location}-${var.admin.name}${random_integer.int.result}-${terraform.workspace}"
   storage_account = can(var.storage.storage_account.resource_group_name) && can(var.storage.storage_account.name) && can(var.storage.storage_account.location) ? var.storage.storage_account : data.external.sa[0].result
 
-  az_command    = try("az aks get-credentials --name ${module.kubernetes.name} --resource-group ${module.resource_group.name} --overwrite", "")
-  web_urls      = { auto_launch_eclwatch = "http://$(kubectl get svc --field-selector metadata.name=eclwatch | awk 'NR==2 {print $4}'):8010" }
-  is_windows_os = substr(pathexpand("~"), 0, 1) == "/" ? false : true
+  elastic4hpcclogs_hpcc_logaccess = "https://raw.githubusercontent.com/hpcc-systems/HPCC-Platform/master/helm/managed/logging/elastic/elastic4hpcclogs-hpcc-logaccess.yaml"
+  az_command                      = try("az aks get-credentials --name ${module.kubernetes.name} --resource-group ${module.resource_group.name} --overwrite", "")
+  web_urls                        = { auto_launch_eclwatch = "http://$(kubectl get svc --field-selector metadata.name=eclwatch | awk 'NR==2 {print $4}'):8010" }
+  is_windows_os                   = substr(pathexpand("~"), 0, 1) == "/" ? false : true
 }

--- a/values/elastic4hpcclogs.yaml
+++ b/values/elastic4hpcclogs.yaml
@@ -1,4 +1,0 @@
-kibana:
-  service:
-    annotations:
-      service.beta.kubernetes.io/azure-load-balancer-internal: "false"


### PR DESCRIPTION
This PR introduces a new remote file that configures ELK as logaccess target by default, and also removes the custom elastic4hpcclogs value file in favor of dynamic set.

Signed-off-by: Godson Fortil <godson.fortil@lexisnexisrisk.com>