### PR TITLE
HPCC-28050 Allow internal and external VNet access to data planes simultaneously 

### DIFF
--- a/modules/storage_account/locals.tf
+++ b/modules/storage_account/locals.tf
@@ -12,9 +12,21 @@ locals {
     var.metadata.resource_group_type != "" ? { resource_group_type = var.metadata.resource_group_type } : {}
   ) : module.metadata.names
 
-  tags     = var.disable_naming_conventions ? merge(var.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }) : merge(module.metadata.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }, try(var.tags))
-  vnet     = can(var.virtual_network.private_subnet_id) && can(var.virtual_network.public_subnet_id) ? tomap({ private_subnet_id = var.virtual_network.private_subnet_id, public_subnet_id = var.virtual_network.public_subnet_id }) : tomap({ private_subnet_id = data.external.vnet[0].result.private_subnet_id, public_subnet_id = data.external.vnet[0].result.public_subnet_id })
+  tags = var.disable_naming_conventions ? merge(var.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }) : merge(module.metadata.tags, { "admin" = var.admin.name, "email" = var.admin.email, "workspace" = terraform.workspace }, try(var.tags))
+
+  external_vnet = can(var.virtual_network.private_subnet_id) && can(var.virtual_network.public_subnet_id) ? tomap({
+    external_private_subnet_id = var.virtual_network.private_subnet_id, external_public_subnet_id = var.virtual_network.public_subnet_id
+  }) : null
+
+  internal_vnet = can(data.external.vnet[0].result) ? tomap({
+    internal_private_subnet_id = data.external.vnet[0].result.private_subnet_id,
+    internal_public_subnet_id  = data.external.vnet[0].result.public_subnet_id
+  }) : null
+
+  vnet = merge(local.internal_vnet, local.external_vnet)
+
   location = can(var.virtual_network.location) ? var.virtual_network.location : data.external.vnet[0].result.location
+
   storage_shares = { "dalishare" = var.storage.quotas.dali, "dllsshare" = var.storage.quotas.dll, "sashashare" = var.storage.quotas.sasha,
   "datashare" = var.storage.quotas.data, "lzshare" = var.storage.quotas.lz }
 }


### PR DESCRIPTION
This change allows multiple users to access the same data planes and see each other's workunits.

Signed-off-by: Godson Fortil <godson.fortil@lexisnexisrisk.com>