### PR TITLE
HPCC-29321 Stop users from using hpccdemo as a tag.

### DIFF
--- a/modules/storage_accounts/variables.tf
+++ b/modules/storage_accounts/variables.tf
@@ -4,6 +4,17 @@ variable "admin" {
     name  = string
     email = string
   })
+
+  validation {
+    condition = try(
+      regex("hpccdemo", var.admin.name) != "hpccdemo", true
+      ) && try(
+      regex("hpccdemo", var.admin.email) != "hpccdemo", true
+      ) && try(
+      regex("@example.com", var.admin.email) != "@example.com", true
+    )
+    error_message = "Your name and email are required in the admin block and must not contain hpccdemo or @example.com."
+  }
 }
 
 variable "disable_naming_conventions" {

--- a/modules/virtual_network/variables.tf
+++ b/modules/virtual_network/variables.tf
@@ -4,6 +4,17 @@ variable "admin" {
     name  = string
     email = string
   })
+
+  validation {
+    condition = try(
+      regex("hpccdemo", var.admin.name) != "hpccdemo", true
+      ) && try(
+      regex("hpccdemo", var.admin.email) != "hpccdemo", true
+      ) && try(
+      regex("@example.com", var.admin.email) != "@example.com", true
+    )
+    error_message = "Your name and email are required in the admin block and must not contain hpccdemo or @example.com."
+  }
 }
 
 variable "disable_naming_conventions" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,17 @@ variable "admin" {
     name  = string
     email = string
   })
+
+  validation {
+    condition = try(
+      regex("hpccdemo", var.admin.name) != "hpccdemo", true
+      ) && try(
+      regex("hpccdemo", var.admin.email) != "hpccdemo", true
+      ) && try(
+      regex("@example.com", var.admin.email) != "@example.com", true
+    )
+    error_message = "Your name and email are required in the admin block and must not contain hpccdemo or @example.com."
+  }
 }
 
 variable "expose_services" {


### PR DESCRIPTION
This change will stop users from using hpccdemo as an admin tag and any combinations of hpccdemo and @example.com as an email tag.